### PR TITLE
Adding request id logging support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ module.exports.bunyan = {
   /** If true, a child logger is injected on each request */
   injectRequestLogger: true,
 
+  /** Name of the request id property assigned to the request logger */
+  requestIdProperty: 'req_id',
+
   /** If true, log uncaughtExceptions and terminate the process */
   logUncaughtException: false,
 
@@ -49,6 +52,21 @@ By default, `sails-hook-bunyan` will log to `stdout`. If a `filePath` is
 specified, it will instead log to the named file. If both `filePath` and
 `bunyan.streams` are specified, the file stream is appended to the list of given
 streams.
+
+The request id source can also be customized by configuring a requestIdProvider.
+For example, the heroku style (https://devcenter.heroku.com/articles/http-request-id)
+could be accomplished with:
+
+```js
+var uuid = require( 'uuid' );
+module.exports.log = {
+
+    requestIdProvider: function( req ) {
+        req.id = req.headers['x-request-id'] || uuid.v4();
+        return req.id;
+    }
+};
+```
 
 For `rotationSignal`, it's recommended to use `SIGHUP`. `SIGUSR1` is reserved
 by Node, and will start the debugger. `SIGUSR2` is reserved by Sails, and will

--- a/package.json
+++ b/package.json
@@ -25,13 +25,15 @@
   },
   "homepage": "https://github.com/building5/sails-hook-bunyan",
   "dependencies": {
-    "bunyan": "^1.0.0"
+    "bunyan": "^1.0.0",
+    "uuid": "^2.0.1"
   },
   "devDependencies": {
     "chai": "^2.3.0",
     "dirty-chai": "^1.2.1",
     "jscs": "^1.13.1",
     "jshint": "^2.8.0",
+    "lodash": "^3.9.3",
     "mocha": "^2.2.5",
     "sails": "^0.11.0",
     "sinon": "^1.14.1",


### PR DESCRIPTION
By default, every log message for the lifetime of a request is now tagged with a unique req_id property.  This makes filtering to all the messages for a given request trivial.

The request id property is configurable, as well as the source of the request id.
