### PR TITLE
Fixing injectRequestLogger to copy over when false

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,6 +83,11 @@ module.exports = function(sails) {
         bunyanConfig.rotationSignal = oldConfig.rotationSignal;
       }
 
+      var oldInjectRequestLogger = oldConfig.injectRequestLogger;
+      if (oldInjectRequestLogger || oldInjectRequestLogger === false) {
+        bunyanConfig.injectRequestLogger = oldConfig.injectRequestLogger;
+      }
+
       return config;
     },
 

--- a/test/sails-hook-bunyan.spec.js
+++ b/test/sails-hook-bunyan.spec.js
@@ -160,7 +160,7 @@ describe('sails-hook-bunyan', function() {
       }, done);
     });
 
-    it('should inject a request logger', function(done) {
+    it('should not inject a request logger', function(done) {
       sails.request({
         method: 'get',
         url: '/test'


### PR DESCRIPTION
In writing my new sails hook I discovered that you couldn't actually disable the request logger injection, since it wasn't being copied over like the other variables.
