### PR TITLE
Updating peerDependencies to prevent Travis CI crashes

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "sinon-chai": "^2.7.0"
   },
   "peerDependencies": {
-    "sails": "^0.11.0"
+    "sails": ">=0.11.0"
   },
   "sails": {
     "isHook": true


### PR DESCRIPTION
This hot fix is necessary to prevent the Travis CI crashes on build. When Travis start to install npm dependencies, it crash's if the sails have a different version of 0.11.0. But this implementation works until this moment, at sails version of 0.12.4.